### PR TITLE
fixed a typo

### DIFF
--- a/gqp_mc/fitters.py
+++ b/gqp_mc/fitters.py
@@ -731,7 +731,7 @@ class iFSPS(Fitter):
         sq_means = []
 
         for m in r_sample:
-            means.append(np.mean(n))
+            means.append(np.mean(m))
             sq_means.append(np.mean(m**2))
 
         tot_mean = np.mean(means)


### PR DESCRIPTION
There was a typo in ACM()
np.mean(n) -> np.mean(m)